### PR TITLE
Fix issue where we get 'Unable to resolve image' if the user does not…

### DIFF
--- a/astro/src/lib/api.js
+++ b/astro/src/lib/api.js
@@ -1,7 +1,7 @@
 import { useSanityClient } from "astro-sanity";
 
 export async function getAllPosts() {
-  const query = `*[_type == 'post']{"categoryData": categories[]->{slug, title},author -> {name}, ...} | order(publishedAt desc)`;
+  const query = `*[_type == 'post']{..., "categoryData": categories[]->{slug, title}, author->{name, slug, image, bio}} | order(publishedAt desc)`;
   const data = await useSanityClient().fetch(query);
   return data;
 }

--- a/astro/src/pages/blog/[slug].astro
+++ b/astro/src/pages/blog/[slug].astro
@@ -24,11 +24,15 @@ export async function getStaticPaths() {
 
 const { post } = Astro.props;
 
+const resolvedImage = post.mainImage
+  ? getSanityImageURL(post.mainImage).width(1200).url()
+  : null;
+
 const seo = {
   title: post.title,
   description: post.description,
-  image: getSanityImageURL(post.mainImage).width(1200).url(),
-}
+  image: resolvedImage,
+};
 ---
 
 <Layout seo={seo}>

--- a/sanity/schemas/post.js
+++ b/sanity/schemas/post.js
@@ -41,6 +41,7 @@ export default {
       name: 'publishedAt',
       title: 'Published at',
       type: 'datetime',
+      validation: Rule => Rule.required(),
     },
     {
       name: 'excerpt',

--- a/sanity/schemas/post.js
+++ b/sanity/schemas/post.js
@@ -42,7 +42,7 @@ export default {
       title: 'Published at',
       type: 'datetime',
       validation: Rule => Rule.required(),
-      initialValue: (new Date()).getTime()
+      initialValue: new Date().toISOString()
     },
     {
       name: 'excerpt',

--- a/sanity/schemas/post.js
+++ b/sanity/schemas/post.js
@@ -42,6 +42,7 @@ export default {
       title: 'Published at',
       type: 'datetime',
       validation: Rule => Rule.required(),
+      initialValue: (new Date()).getTime()
     },
     {
       name: 'excerpt',


### PR DESCRIPTION
This fixes an issues I encountered first stab at getting up and running:

-  where I hadn't selected a post image on the Sanity CMS side for a particular blog post. I think we should probably be able to handle that as a valid use case hence my fix. It seems that `null` is working fine as the fallback there. Also, I noticed that everywhere else in the code we're using conditional rendering with `{post.mainImage &&`... so this feels pretty consistent with that ;-)
- Missing Author name
- default `publishedDate` and validation required